### PR TITLE
Change version to 1.1.0 and fix description typo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@channel.io/eslint-plugin",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@channel.io/eslint-plugin",
-  "version": "1.0.0",
-  "description": "eslint plugins for channel.io web",
+  "version": "1.1.0",
+  "description": "eslint plugin for channel.io web",
   "author": "Channel Corp.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Change version to 1.1.0 (minor ver. - new feature)
- Fix description typo (`eslint plugins` to `eslint plugin`)