### PR TITLE
Define rule option about checking enum member name

### DIFF
--- a/__tests__/pascal-case-enum-name.js
+++ b/__tests__/pascal-case-enum-name.js
@@ -22,6 +22,26 @@ ruleTester.run('pascal-case-enum-name', rule, {
         }
       `,
     },
+    {
+      code: `
+        enum FooBar {
+          Error,
+          NORMAL,
+          SUCCESS_NORMAL_1,
+        }
+      `,
+      options: [false, false],
+    },
+    {
+      code: `
+        enum FooBar {
+          Error,
+          NORMAL,
+          SUCCESS_NORMAL_1,
+        }
+      `,
+      options: [true, false],
+    },
   ],
   invalid: [
     {
@@ -62,6 +82,26 @@ ruleTester.run('pascal-case-enum-name', rule, {
         { message: 'Enum member\'s first charactor must be upper case.' },
         { message: 'Enum member\'s first charactor must be upper case.' },
         { message: 'Enum member\'s first charactor must be upper case.' },
+      ],
+    },
+    {
+      code: `
+        enum fooBar {
+          error,
+          normal,
+          success,
+        }
+      `,
+      output: `
+        enum FooBar {
+          error,
+          normal,
+          success,
+        }
+      `,
+      options: [false, false],
+      errors: [
+        { message: 'Enum\'s first charactor must be upper case.' },
       ],
     },
     {

--- a/docs/pascal-case-enum-name.md
+++ b/docs/pascal-case-enum-name.md
@@ -4,13 +4,17 @@
 ## Concept
 - Enum의 첫번째 문자는 무조건 대문자여야 합니다.
 
+## Options
+- `checkMemberNameStartByUpperCase: boolean` (기본값 true): Member의 이름이 대문자로 시작하는지 확인합니다.
+- `checkMemberNamePascal: boolean` (기본값 true): Member의 이름에 대해 pascal case인지 확인합니다.
+
 ## Logic
 1. TSEnumDeclaration 에서 id.name이 `^[a-z]` 인지 확인합니다.
     - 만약 그렇다면 `Enum's first charactor must be upper case.`를 표시합니다.
     - fix option을 사용할 경우 TSEnumDeclaration id의 첫번째 문자를 대문자로 변경합니다.
-1. TSEnumDeclaration 에서 members의 각각 id.name이 `^[a-z]` 인지 확인합니다.
+1. TSEnumDeclaration 에서 members의 각각 id.name이 `^[a-z]` 인지 확인합니다. (단, `checkMemberNameStartByUpperCase === true` 일 경우)
     - 만약 그렇다면 `Enum member's first charactor must be upper case.`를 표시합니다.
     - fix option을 사용할 경우 해당 member의 첫번째 문자를 대문자로 변경합니다.
-1. TSEnumDeclaration 에서 members의 각각 id.name이 `^[A-Z0-9_]+$` 인지 확인합니다.
+1. TSEnumDeclaration 에서 members의 각각 id.name이 `^[A-Z0-9_]+$` 인지 확인합니다. (단, `checkMemberNamePascal === true` 일 경우)
     - 만약 그렇다면 `Enum member name must be pascal case.`를 표시합니다.
     - fix option을 사용할 경우 해당 member의 첫번째 문자 외에 전부 소문자로 변경합니다. `_` 뒤에 있는 문자는 `_`를 삭제하고 대문자로 변경합니다.

--- a/rules/pascal-case-enum-name.js
+++ b/rules/pascal-case-enum-name.js
@@ -8,6 +8,7 @@ module.exports = {
     fixable: 'code',
   },
   create(context) {
+    const [checkMemberNameStartByUpperCase = true, checkMemberNamePascal = true] = context.options
     return {
       TSEnumDeclaration({ id, members }) {
         if (/^[a-z]/.test(id.name)) {
@@ -19,25 +20,27 @@ module.exports = {
             },
           })
         }
-        members.forEach(member => {
-          if (/^[a-z]/.test(member.id.name)) {
-            context.report({
-              node: member.id,
-              message: 'Enum member\'s first charactor must be upper case.',
-              fix: fixer => {
-                return fixer.replaceText(member.id, `${member.id.name.charAt(0).toUpperCase()}${member.id.name.slice(1)}`)
-              },
-            })
-          } else if (/^[A-Z0-9_]+$/.test(member.id.name)) {
-            context.report({
-              node: member.id,
-              message: 'Enum member name must be pascal case.',
-              fix: fixer => {
-                return fixer.replaceText(member.id, `${member.id.name.charAt(0)}${member.id.name.slice(1).toLowerCase().replace(/_(.)/g, (match, char) => char.toUpperCase())}`)
-              },
-            })
-          }
-        })
+        if (checkMemberNameStartByUpperCase || checkMemberNamePascal) {
+          members.forEach(member => {
+            if (checkMemberNameStartByUpperCase && /^[a-z]/.test(member.id.name)) {
+              context.report({
+                node: member.id,
+                message: 'Enum member\'s first charactor must be upper case.',
+                fix: fixer => {
+                  return fixer.replaceText(member.id, `${member.id.name.charAt(0).toUpperCase()}${member.id.name.slice(1)}`)
+                },
+              })
+            } else if (checkMemberNamePascal && /^[A-Z0-9_]+$/.test(member.id.name)) {
+              context.report({
+                node: member.id,
+                message: 'Enum member name must be pascal case.',
+                fix: fixer => {
+                  return fixer.replaceText(member.id, `${member.id.name.charAt(0)}${member.id.name.slice(1).toLowerCase().replace(/_(.)/g, (match, char) => char.toUpperCase())}`)
+                },
+              })
+            }
+          })
+        }
       },
     }
   },


### PR DESCRIPTION
- `checkMemberNameStartByUpperCase: boolean` (기본값 true): Member의 이름이 대문자로 시작하는지 확인합니다.
- `checkMemberNamePascal: boolean` (기본값 true): Member의 이름에 대해 pascal case인지 확인합니다.