### PR TITLE
feature: add new rule to restrict template literal argument for translate method

### DIFF
--- a/__tests__/no-translate-with-template-literal.js
+++ b/__tests__/no-translate-with-template-literal.js
@@ -1,0 +1,46 @@
+const ruleTester = require('./ruleTester')
+const rule = require('../rules/no-translate-with-template-literal')
+
+ruleTester.run('no-translate-with-template-literal', rule, {
+  valid: [
+    {
+      code: `translate('my.foo.key')`,
+    },
+    {
+      code: `
+        const TRANSLATE_KEY = 'my.foo.key'
+        
+        const translated = translate(TRANSLATE_KEY)
+      `,
+    },
+    {
+      code: `
+        const TRANSLATE_KEY = 'my.foo.key'
+        
+        const translated1 = i18n(TRANSLATE_KEY)
+        const translated2 = t(TRANSLATE_KEY)
+      `,
+      options: [{ translateFuncNames: ['t', 'i18n'] }]
+    },
+  ],
+  invalid: [
+    {
+      code: 'translate(`my.foo.${first}`)',
+      errors: [{ message: 'Do not call translation method with template literal.' }],
+    },
+    {
+      code: 'translate(`my.foo.${second}.${third}`)',
+      errors: [{ message: 'Do not call translation method with template literal.' }],
+    },
+    {
+      code: 'translate(`my.foo.${second}.${third}.fourth`)',
+      errors: [{ message: 'Do not call translation method with template literal.' }],
+    },
+    {
+      code: `
+        someItems.map((item) => ${'translate(`my.foo.${item.type}`)'})
+      `,
+      errors: [{ message: 'Do not call translation method with template literal.' }],
+    },
+  ],
+})

--- a/docs/no-translate-with-template-literal.md
+++ b/docs/no-translate-with-template-literal.md
@@ -1,0 +1,12 @@
+# no-translate-with-template-literal
+> Restrict template literal argument for translation method
+
+## Concept
+- 번역 함수의 인자에는 template literal 문법의 문자열을 사용할 수 없습니다.
+
+## Options
+- `translateFuncNames: string[]` (기본값 `['translate']`): 번역 함수의 이름을 지정합니다.
+
+## Logic
+1. CallExpression 에서 함수의 이름이 `translateFuncName`인지 여부를 확인합니다.
+2. 함수의 인자가 template literal 인지 확인합니다.

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const hooksDepsElementNewline = require('./rules/hooks-deps-element-newline')
 const noClassnamesWithOneArgument = require('./rules/no-classnames-with-one-argument')
+const noTranslateWithTemplateLiteral = require('./rules/no-translate-with-template-literal')
 const pascalCaseEnumName = require('./rules/pascal-case-enum-name')
 const pascalCaseInterfaceName = require('./rules/pascal-case-interface-name')
 const pascalCaseTypeName = require('./rules/pascal-case-type-name')
@@ -8,6 +9,7 @@ module.exports = {
   rules: {
     'hooks-deps-element-newline': hooksDepsElementNewline,
     'no-classnames-with-one-argument': noClassnamesWithOneArgument,
+    'no-translate-with-template-literal': noTranslateWithTemplateLiteral,
     'pascal-case-enum-name': pascalCaseEnumName,
     'pascal-case-interface-name': pascalCaseInterfaceName,
     'pascal-case-type-name': pascalCaseTypeName,

--- a/rules/no-translate-with-template-literal.js
+++ b/rules/no-translate-with-template-literal.js
@@ -1,0 +1,39 @@
+module.exports = {
+  meta: {
+    type: 'problem',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          translateFuncNames: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+          },
+        },
+      }
+    ],
+    docs: {
+      description: 'Do not call translation method with template literal',
+      category: 'Possible Problems',
+    },
+  },
+  create(context) {
+    const translateFuncNames = context.options[0]?.translateFuncNames || ['translate']
+    return {
+      CallExpression(node) {
+        const { callee, arguments: args } = node
+        if (
+          translateFuncNames.includes(callee.name) &&
+          args[0].type === 'TemplateLiteral'
+        ) {
+          context.report({
+            node,
+            message: 'Do not call translation method with template literal.',
+          })
+        }
+      }
+    }
+  },
+}


### PR DESCRIPTION
# no-translate-with-template-literal
> Restrict template literal argument for translation method

## Concept
- 번역 함수의 인자에는 template literal 문법의 문자열을 사용할 수 없습니다.

## Options
- `translateFuncNames: string[]` (기본값 `['translate']`): 번역 함수의 이름을 지정합니다.

## Logic
1. CallExpression 에서 함수의 이름이 `translateFuncName`인지 여부를 확인합니다.
2. 함수의 인자가 template literal 인지 확인합니다.
