### PR TITLE
Find template token in as expression

### DIFF
--- a/__tests__/no-translate-with-template-literal.js
+++ b/__tests__/no-translate-with-template-literal.js
@@ -7,6 +7,12 @@ ruleTester.run('no-translate-with-template-literal', rule, {
       code: `translate('my.foo.key')`,
     },
     {
+      code: `translate('my.foo.key' as string)`,
+    },
+    {
+      code: `translate('my.foo.key' as const)`,
+    },
+    {
       code: `
         const TRANSLATE_KEY = 'my.foo.key'
         
@@ -34,6 +40,14 @@ ruleTester.run('no-translate-with-template-literal', rule, {
     },
     {
       code: 'translate(`my.foo.${second}.${third}.fourth`)',
+      errors: [{ message: 'Do not call translation method with template literal.' }],
+    },
+    {
+      code: 'translate(`my.foo.${second}.${third}.fourth` as string)',
+      errors: [{ message: 'Do not call translation method with template literal.' }],
+    },
+    {
+      code: 'translate(`my.foo.${second}.${third}.fourth` as const)',
       errors: [{ message: 'Do not call translation method with template literal.' }],
     },
     {

--- a/rules/no-translate-with-template-literal.js
+++ b/rules/no-translate-with-template-literal.js
@@ -20,13 +20,14 @@ module.exports = {
     },
   },
   create(context) {
+    const sourceCode = context.getSourceCode()
     const translateFuncNames = context.options[0]?.translateFuncNames || ['translate']
     return {
       CallExpression(node) {
-        const { callee, arguments: args } = node
+        const { callee } = node
         if (
           translateFuncNames.includes(callee.name) &&
-          args[0].type === 'TemplateLiteral'
+          sourceCode.getTokens(node).some(token => token.type === 'Template')
         ) {
           context.report({
             node,


### PR DESCRIPTION
# Summary
#17 의 버그 수정

```translate(`a.b.${c}` as TranslateKey)``` 와 같은 형태로 주로 사용하게 됩니다. 그런데 지금 rule은 해당 경우를 캐치하지 못하는 문제가 있습니다. (args[0].type가 TSAsExpression 가 되고, 그 하위에 TemplateLiteral가 들어갑니다.)

# Details
- 내부의 token을 인식하여 작동하는 방식으로 변경합니다.