### PR TITLE
v1.2.1

### DIFF
--- a/__tests__/no-translate-with-template-literal.js
+++ b/__tests__/no-translate-with-template-literal.js
@@ -7,6 +7,12 @@ ruleTester.run('no-translate-with-template-literal', rule, {
       code: `translate('my.foo.key')`,
     },
     {
+      code: `translate('my.foo.key' as string)`,
+    },
+    {
+      code: `translate('my.foo.key' as const)`,
+    },
+    {
       code: `
         const TRANSLATE_KEY = 'my.foo.key'
         
@@ -34,6 +40,14 @@ ruleTester.run('no-translate-with-template-literal', rule, {
     },
     {
       code: 'translate(`my.foo.${second}.${third}.fourth`)',
+      errors: [{ message: 'Do not call translation method with template literal.' }],
+    },
+    {
+      code: 'translate(`my.foo.${second}.${third}.fourth` as string)',
+      errors: [{ message: 'Do not call translation method with template literal.' }],
+    },
+    {
+      code: 'translate(`my.foo.${second}.${third}.fourth` as const)',
       errors: [{ message: 'Do not call translation method with template literal.' }],
     },
     {

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const noTranslateWithTemplateLiteral = require('./rules/no-translate-with-templa
 const pascalCaseEnumName = require('./rules/pascal-case-enum-name')
 const pascalCaseInterfaceName = require('./rules/pascal-case-interface-name')
 const pascalCaseTypeName = require('./rules/pascal-case-type-name')
+const preventDestructuredArgumentCallbackInIntersectionObserver = require('./rules/prevent-destructured-argument-callback-in-intersection-observer')
 
 module.exports = {
   rules: {
@@ -13,5 +14,6 @@ module.exports = {
     'pascal-case-enum-name': pascalCaseEnumName,
     'pascal-case-interface-name': pascalCaseInterfaceName,
     'pascal-case-type-name': pascalCaseTypeName,
+    'prevent-destructured-argument-callback-in-intersection-observer': preventDestructuredArgumentCallbackInIntersectionObserver,
   },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@channel.io/eslint-plugin",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@channel.io/eslint-plugin",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "eslint plugin for channel.io web",
   "author": "Channel Corp.",
   "main": "index.js",

--- a/rules/no-translate-with-template-literal.js
+++ b/rules/no-translate-with-template-literal.js
@@ -20,13 +20,14 @@ module.exports = {
     },
   },
   create(context) {
+    const sourceCode = context.getSourceCode()
     const translateFuncNames = context.options[0]?.translateFuncNames || ['translate']
     return {
       CallExpression(node) {
-        const { callee, arguments: args } = node
+        const { callee } = node
         if (
           translateFuncNames.includes(callee.name) &&
-          args[0].type === 'TemplateLiteral'
+          sourceCode.getTokens(node).some(token => token.type === 'Template')
         ) {
           context.report({
             node,


### PR DESCRIPTION
# Bugfixes
- 누락된 prevent-destructured-argument-callback-in-intersection-observer export 추가 (#66) (@manuel)
- as 구문 내의 TemplateLiteral을 인식하지 못하는 문제 수정 (#65) (@manuel)
